### PR TITLE
refactor of existing resolvers and typedefs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "18.0.11",
         "autoprefixer": "10.4.14",
         "bcrypt": "^5.1.0",
+        "cookie": "^0.5.0",
         "deepmerge": "^4.3.1",
         "jose": "^4.14.1",
         "jsonwebtoken": "^9.0.0",
@@ -40,9 +41,11 @@
         "@graphql-codegen/typescript-react-apollo": "^3.3.7",
         "@graphql-codegen/typescript-resolvers": "3.2.0",
         "@types/bcrypt": "^5.0.0",
+        "@types/cookie": "^0.5.1",
         "@types/jsonwebtoken": "^9.0.1",
         "@types/mui-image": "^1.0.1",
         "@types/validator": "^13.7.15",
+        "encoding": "^0.1.13",
         "ts-node": "^10.9.1"
       }
     },
@@ -3077,6 +3080,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
+      "integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
+      "dev": true
+    },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -4494,6 +4503,27 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/error-ex": {
@@ -10640,6 +10670,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
+      "integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -11746,6 +11782,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "devOptional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "18.0.11",
     "autoprefixer": "10.4.14",
     "bcrypt": "^5.1.0",
+    "cookie": "^0.5.0",
     "deepmerge": "^4.3.1",
     "jose": "^4.14.1",
     "jsonwebtoken": "^9.0.0",
@@ -45,9 +46,11 @@
     "@graphql-codegen/typescript-react-apollo": "^3.3.7",
     "@graphql-codegen/typescript-resolvers": "3.2.0",
     "@types/bcrypt": "^5.0.0",
+    "@types/cookie": "^0.5.1",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/mui-image": "^1.0.1",
     "@types/validator": "^13.7.15",
+    "encoding": "^0.1.13",
     "ts-node": "^10.9.1"
   }
 }

--- a/src/apollo/typeDefs.ts
+++ b/src/apollo/typeDefs.ts
@@ -28,22 +28,7 @@ export const typeDefs = gql`
   }
 
   type UserInputValidation {
-    status: Int!
-    message: String!
     token: ID!
-  }
-
-  union ValidUserResult = ValidUserSuccess | ValidUserError
-
-  type ValidUserError {
-    status: Int!
-    message: String!
-    type: String!
-  }
-
-  type ValidUserSuccess {
-    user: FilteredUser!
-    type: String!
   }
 
   input ValidateLoginInput {
@@ -53,7 +38,7 @@ export const typeDefs = gql`
 
   type Query {
     allUsers: [User!]!
-    validUser: ValidUserResult!
+    validUser: FilteredUser!
   }
 
   type Mutation {

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -2,13 +2,10 @@ import { startServerAndCreateNextHandler } from '@as-integrations/next';
 import { ApolloServer } from '@apollo/server';
 import { NextRequest } from 'next/server';
 import { schema } from '../../../apollo';
-import { authorizedUser } from '../../../../utils/authHelpers';
 
 const server = new ApolloServer<any>(schema);
 
-const handler = startServerAndCreateNextHandler<NextRequest>(server, { context: async req => ({ 
- authResult: await authorizedUser(req.headers.get('authorization') ?? '') 
-}) });
+const handler = startServerAndCreateNextHandler<NextRequest>(server, { context: async req => ({ req }) });
 
 export async function GET(request: NextRequest) {
   return handler(request);

--- a/src/app/components/AuthModal/index.tsx
+++ b/src/app/components/AuthModal/index.tsx
@@ -10,6 +10,7 @@ import Modal from '@mui/material/Modal';
 import AuthModalInputs from './AuthModalInputs';
 import { useLoginUserMutation, ValidateLoginInput } from '@/generated/graphql-frontend';
 import { getClient } from '../../../../lib/client';
+import { CircularProgress, Alert } from '@mui/material';
 
 const client = getClient();
 
@@ -42,7 +43,6 @@ const AuthModal = ({ isSignin }: AuthModalProps)  =>{
 
   const [login, { data, loading: loginLoading, error: loginError }] = useLoginUserMutation({ client });
 
-
   useEffect(() => {
     if (isSignin) {
       if (inputs.password && inputs.email) return setDisabled(false);
@@ -64,7 +64,8 @@ const AuthModal = ({ isSignin }: AuthModalProps)  =>{
     });
   };
 
-  const handleClick = async () => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     if (isSignin) {
       if (!loginLoading) {
         const loginResult = await login({
@@ -75,11 +76,11 @@ const AuthModal = ({ isSignin }: AuthModalProps)  =>{
               } as ValidateLoginInput
             }
         });
+        console.log(loginResult);
       }
     }
   };
   
-
   return (
     <div>
       <button 
@@ -96,33 +97,43 @@ const AuthModal = ({ isSignin }: AuthModalProps)  =>{
         className="text-black"
       >
         <Box sx={style}>
-         <div className="p-2 h-[600px]">
-          <div className="uppercase font-bold text-center pb-2 border-b mb-2 border-gray-400">
-            <p className="text-sm">
-              {renderContent("Sign In", "Create Account")}
-            </p>
-          </div>
-          <div className="m-auto">
-            <h2 className="text-2xl font-light text-center">
-              {renderContent("Log Into Your Account", "Create your OpenTable Account")}
-            </h2>
-            <AuthModalInputs 
-              inputs={inputs} 
-              handleChangeInput={handleChangeInput} 
-              isSignin={isSignin}
-            />
-            <button 
-              className="uppercase bg-red-600 w-full text-white p-3 rounded text-sm mb-5 disabled:bg-gray-400" 
-              disabled={disabled}
-              onClick={handleClick}
-            >
-              {renderContent(
-                "Sign In",
-                "Create Account"
-              )}
-            </button>
-          </div>
-         </div>
+         {loginLoading ? (
+           <div className="py-24 px-2 h-[600px] flex justify-center">
+              <CircularProgress />
+            </div>
+          ) : (
+            <form className="p-2 h-[600px]" onSubmit={handleSubmit}>
+              {loginError ? 
+              <Alert severity="error" className="mb-4 bg-red-200 text-black">
+                {loginError.message}
+              </Alert> 
+              : null}
+              <div className="uppercase font-bold text-center pb-2 border-b mb-2 border-gray-400">
+                <p className="text-sm">
+                  {renderContent("Sign In", "Create Account")}
+                </p>
+            </div>
+            <div className="m-auto">
+              <h2 className="text-2xl font-light text-center">
+                {renderContent("Log Into Your Account", "Create your OpenTable Account")}
+              </h2>
+              <AuthModalInputs 
+                inputs={inputs} 
+                handleChangeInput={handleChangeInput} 
+                isSignin={isSignin}
+              />
+              <button 
+                className="uppercase bg-red-600 w-full text-white p-3 rounded text-sm mb-5 disabled:bg-gray-400" 
+                disabled={disabled}
+                type="submit"
+              >
+                {renderContent(
+                  "Sign In",
+                  "Create Account"
+                )}
+              </button>
+            </div>
+          </form>)}
         </Box>
       </Modal>
     </div>

--- a/src/generated/graphql-backend.ts
+++ b/src/generated/graphql-backend.ts
@@ -42,7 +42,7 @@ export type MutationRegisterUserArgs = {
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<User>;
-  validUser: ValidUserResult;
+  validUser: FilteredUser;
 };
 
 export type RegisterUserInput = {
@@ -66,24 +66,7 @@ export type User = {
 
 export type UserInputValidation = {
   __typename?: 'UserInputValidation';
-  message: Scalars['String'];
-  status: Scalars['Int'];
   token: Scalars['ID'];
-};
-
-export type ValidUserError = {
-  __typename?: 'ValidUserError';
-  message: Scalars['String'];
-  status: Scalars['Int'];
-  type: Scalars['String'];
-};
-
-export type ValidUserResult = ValidUserError | ValidUserSuccess;
-
-export type ValidUserSuccess = {
-  __typename?: 'ValidUserSuccess';
-  type: Scalars['String'];
-  user: FilteredUser;
 };
 
 export type ValidateLoginInput = {
@@ -158,15 +141,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-/** Mapping of union types */
-export type ResolversUnionTypes = {
-  ValidUserResult: ( ValidUserError ) | ( ValidUserSuccess );
-};
 
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = {
-  ValidUserResult: ( ValidUserError ) | ( ValidUserSuccess );
-};
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
@@ -180,9 +155,6 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>;
   User: ResolverTypeWrapper<User>;
   UserInputValidation: ResolverTypeWrapper<UserInputValidation>;
-  ValidUserError: ResolverTypeWrapper<ValidUserError>;
-  ValidUserResult: ResolverTypeWrapper<ResolversUnionTypes['ValidUserResult']>;
-  ValidUserSuccess: ResolverTypeWrapper<ValidUserSuccess>;
   ValidateLoginInput: ValidateLoginInput;
 };
 
@@ -198,9 +170,6 @@ export type ResolversParentTypes = {
   String: Scalars['String'];
   User: User;
   UserInputValidation: UserInputValidation;
-  ValidUserError: ValidUserError;
-  ValidUserResult: ResolversUnionParentTypes['ValidUserResult'];
-  ValidUserSuccess: ValidUserSuccess;
   ValidateLoginInput: ValidateLoginInput;
 };
 
@@ -220,7 +189,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   allUsers?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>;
-  validUser?: Resolver<ResolversTypes['ValidUserResult'], ParentType, ContextType>;
+  validUser?: Resolver<ResolversTypes['FilteredUser'], ParentType, ContextType>;
 };
 
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
@@ -234,26 +203,7 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
 };
 
 export type UserInputValidationResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserInputValidation'] = ResolversParentTypes['UserInputValidation']> = {
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  status?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   token?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ValidUserErrorResolvers<ContextType = any, ParentType extends ResolversParentTypes['ValidUserError'] = ResolversParentTypes['ValidUserError']> = {
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  status?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ValidUserResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['ValidUserResult'] = ResolversParentTypes['ValidUserResult']> = {
-  __resolveType: TypeResolveFn<'ValidUserError' | 'ValidUserSuccess', ParentType, ContextType>;
-};
-
-export type ValidUserSuccessResolvers<ContextType = any, ParentType extends ResolversParentTypes['ValidUserSuccess'] = ResolversParentTypes['ValidUserSuccess']> = {
-  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  user?: Resolver<ResolversTypes['FilteredUser'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -263,8 +213,5 @@ export type Resolvers<ContextType = any> = {
   Query?: QueryResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
   UserInputValidation?: UserInputValidationResolvers<ContextType>;
-  ValidUserError?: ValidUserErrorResolvers<ContextType>;
-  ValidUserResult?: ValidUserResultResolvers<ContextType>;
-  ValidUserSuccess?: ValidUserSuccessResolvers<ContextType>;
 };
 

--- a/src/generated/graphql-frontend.ts
+++ b/src/generated/graphql-frontend.ts
@@ -43,7 +43,7 @@ export type MutationRegisterUserArgs = {
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<User>;
-  validUser: ValidUserResult;
+  validUser: FilteredUser;
 };
 
 export type RegisterUserInput = {
@@ -67,24 +67,7 @@ export type User = {
 
 export type UserInputValidation = {
   __typename?: 'UserInputValidation';
-  message: Scalars['String'];
-  status: Scalars['Int'];
   token: Scalars['ID'];
-};
-
-export type ValidUserError = {
-  __typename?: 'ValidUserError';
-  message: Scalars['String'];
-  status: Scalars['Int'];
-  type: Scalars['String'];
-};
-
-export type ValidUserResult = ValidUserError | ValidUserSuccess;
-
-export type ValidUserSuccess = {
-  __typename?: 'ValidUserSuccess';
-  type: Scalars['String'];
-  user: FilteredUser;
 };
 
 export type ValidateLoginInput = {
@@ -97,14 +80,12 @@ export type LoginUserMutationVariables = Exact<{
 }>;
 
 
-export type LoginUserMutation = { __typename?: 'Mutation', loginUser: { __typename?: 'UserInputValidation', status: number, message: string, token: string } };
+export type LoginUserMutation = { __typename?: 'Mutation', loginUser: { __typename?: 'UserInputValidation', token: string } };
 
 
 export const LoginUserDocument = gql`
     mutation LoginUser($input: ValidateLoginInput!) {
   loginUser(input: $input) {
-    status
-    message
     token
   }
 }

--- a/utils/graphql/mutations.graphql
+++ b/utils/graphql/mutations.graphql
@@ -1,7 +1,5 @@
 mutation LoginUser($input: ValidateLoginInput!) {
   loginUser(input: $input) {
-    status
-    message
     token
   }
 }


### PR DESCRIPTION
- removing api wide authentication and instead will place in resolvers individually 
- changing typedefs and resolvers to change returns as graphql handles status codes differently and the previous attempts to capture a traditional http status code was not working as expected
- various cleaning up of code after refactor